### PR TITLE
ArticleLinkButtonにダークモードカラーを適応する

### DIFF
--- a/src/components/ArticleLinkButton.astro
+++ b/src/components/ArticleLinkButton.astro
@@ -8,32 +8,39 @@ const url = `/2023-12-${day.toString().padStart(2, '0')}`
 ---
 
 <style>
+  :root {
+    --button-text-color: var(--y-black-base);
+    --button-border-color: var(--y-white-medium);
+    --button-background-color: var(--y-white-base);
+    --button-hover-text-color: var(--y-blue-medium);
+    --button-hover-border-color: var(--y-white-medium);
+    --button-hover-background-color: rgb(243 244 246 / 100%);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --button-text-color: var(--y-white-base);
+      --button-border-color: var(--y-white-medium);
+      --button-background-color: var(--y-black-base);
+      --button-hover-text-color: var(--y-purple-medium);
+      --button-hover-border-color: var(--y-white-base);
+      --button-hover-background-color: rgb(38 50 62 / 100%);
+    }
+  }
   .link {
     display: block;
     max-width: fit-content;
     margin: var(--y-rhythm-3) 0;
     padding: var(--y-rhythm-1) var(--y-rhythm-2);
     text-decoration: none;
-    color: var(--y-black-base);
-    background-color: var(--y-white-base);
     border-radius: 4px;
-    border: 1px solid var(--y-white-medium);
+    color: var(--button-text-color);
+    background-color: var(--button-background-color);
+    border: 1px solid var(--button-border-color);
   }
   .link:hover {
-    color: var(--y-blue-medium);
-    background-color: rgb(243 244 246);
-  }
-  @media (prefers-color-scheme: dark) {
-    .link {
-      color: var(--y-white-base);
-      background-color: var(--y-black-base);
-      border: 1px solid var(--y-white-medium);
-    }
-    .link:hover {
-      color: var(--y-white-base);
-      background-color: rgb(38 50 62 / 100%);
-      border: 1px solid var(--y-white-base);
-    }
+    color: var(--button-hover-text-color);
+    background-color: var(--button-hover-background-color);
+    border: 1px solid var(--button-hover-border-color);
   }
 </style>
 

--- a/src/components/ArticleLinkButton.astro
+++ b/src/components/ArticleLinkButton.astro
@@ -23,6 +23,18 @@ const url = `/2023-12-${day.toString().padStart(2, '0')}`
     color: var(--y-blue-medium);
     background-color: rgb(243 244 246);
   }
+  @media (prefers-color-scheme: dark) {
+    .link {
+      color: var(--y-white-base);
+      background-color: var(--y-black-base);
+      border: 1px solid var(--y-white-medium);
+    }
+    .link:hover {
+      color: var(--y-white-base);
+      background-color: rgb(38 50 62 / 100%);
+      border: 1px solid var(--y-white-base);
+    }
+  }
 </style>
 
 <a class="link" href={url}>{day}日目の記事</a>


### PR DESCRIPTION
## `prefers-color-scheme: light`

| 通常時 | hover時 |
| ------ | -------- |
| ![Screenshot 2023-12-31 at 11 36 16](https://github.com/yamanoku/2023/assets/1996642/8457ed60-e3fa-462b-9ec3-078d692ca64c) | ![Screenshot 2023-12-31 at 11 36 19](https://github.com/yamanoku/2023/assets/1996642/1eff44ef-f331-4deb-9cc1-573762ad92ff) |

## `prefers-color-scheme: dark`

| 通常時 | hover時 |
| ------ | -------- |
| ![Screenshot 2023-12-31 at 11 36 27](https://github.com/yamanoku/2023/assets/1996642/a37b997e-2a42-40ff-abb5-8a0bbe49389e) | ![Screenshot 2023-12-31 at 11 36 32](https://github.com/yamanoku/2023/assets/1996642/57ed34a4-4483-4c78-a8c2-247ae78430fb) |
